### PR TITLE
Filter out replacements when creating pom.xml

### DIFF
--- a/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/CreatePom.scala
@@ -12,8 +12,9 @@ object CreatePom {
     }
   }
 
-  def translate(dependencies: Graph[MavenCoordinate, Unit]): String = {
-    val mavenCoordinateXml = dependencies.nodes.toList.map {
+  def translate(dependencies: Graph[MavenCoordinate, Unit], model: Model): String = {
+    def replaced(m: MavenCoordinate): Boolean = model.getReplacements.get(m.unversioned).isDefined
+    val mavenCoordinateXml = dependencies.nodes.filterNot(replaced).toList.map {
       d => d.toXml
     }
 
@@ -29,10 +30,10 @@ object CreatePom {
     p.format(pomXml)
   }
 
-  def apply(dependencies: Graph[MavenCoordinate, Unit], path: String): Unit = {
+  def apply(dependencies: Graph[MavenCoordinate, Unit], model: Model, path: String): Unit = {
     scala.xml.XML.save(
       path,
-      scala.xml.XML.loadString(translate(dependencies)),
+      scala.xml.XML.loadString(translate(dependencies, model)),
       "UTF-8",
       true
     )

--- a/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
+++ b/src/scala/com/github/johnynek/bazel_deps/MakeDeps.scala
@@ -42,7 +42,7 @@ object MakeDeps {
         System.exit(1)
       case Success((normalized, shas, duplicates)) =>
         // creates pom xml when path is provided
-        g.pomFile.foreach { fileName => CreatePom(normalized, fileName) }
+        g.pomFile.foreach { fileName => CreatePom(normalized, model, fileName) }
         // build the BUILDs in thirdParty
         val targets = Writer.targets(normalized, model) match {
           case Right(t) => t

--- a/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
+++ b/test/scala/com/github/johnynek/bazel_deps/CreatePomTest.scala
@@ -58,6 +58,65 @@ dependencies:
       val (dependencies, _, _) = MakeDeps.runResolve(model, null).get
       val p = new scala.xml.PrettyPrinter(80, 2)
 
-      assert(CreatePom.translate(dependencies) == p.format(expectedPomXml))
+      assert(CreatePom.translate(dependencies, model) == p.format(expectedPomXml))
+  }
+
+  test("CreatePom ignores dependencies replaced by internal targets" +
+    "replaced by internal targets") {
+    val dependenciesYaml = """
+options:
+  buildHeader: [ "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")" ]
+  languages: [ "java", "scala:2.11.8" ]
+  resolverType: "coursier"
+  resolvers:
+    - id: "mavencentral"
+      type: "default"
+      url: https://repo.maven.apache.org/maven2/
+  transitivity: runtime_deps
+  versionConflictPolicy: highest
+
+dependencies:
+  com.lowagie:
+    itext:
+      lang: java
+      version: "2.1.7"
+      exclude:
+        - "bouncycastle:bcprov-jdk14"
+        - "bouncycastle:bcmail-jdk14"
+        - "bouncycastle:bctsp-jdk14"
+  org.xhtmlrenderer:
+    flying-saucer-pdf:
+      lang: java
+      version: "9.0.3"
+
+replacements:
+  org.xhtmlrenderer:
+    flying-saucer-pdf:
+      lang: java
+      target: "@3rdparty//3rdparty/org/xhtmlrenderer/flying-saucer-pdf"
+"""
+
+    val expectedPomXml =
+      <project>
+        <modelVersion>4.0.0</modelVersion>
+        <dependencies>
+          <dependency>
+            <groupId>com.lowagie</groupId>
+            <artifactId>itext</artifactId>
+            <version>2.1.7</version>
+          </dependency>
+          <dependency>
+            <groupId>org.xhtmlrenderer</groupId>
+            <artifactId>flying-saucer-core</artifactId>
+            <version>9.0.3</version>
+          </dependency>
+        </dependencies>
+      </project>
+
+    val model = Decoders.decodeModel(Yaml, dependenciesYaml).right.get
+    val (dependencies, _, _) = MakeDeps.runResolve(model, null).get
+    val p = new scala.xml.PrettyPrinter(80, 2)
+
+    assert(CreatePom.translate(dependencies, model) == p.format(expectedPomXml))
   }
 }


### PR DESCRIPTION
Some third-party dependencies are replaced by internal targets. These dependencies are listed under [replacements](https://github.com/johnynek/bazel-deps#replacements) in `dependencies.yaml`. Since these are no longer third-party dependencies, we can exclude them from our `pom.xml` file. 

Similar to [creating workspace files](https://github.com/johnynek/bazel-deps/blob/master/src/scala/com/github/johnynek/bazel_deps/Writer.scala#L174), this PR filters out replaced dependencies when creating a `pom.xml`
